### PR TITLE
Update mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,10 +109,12 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
-    marcel (0.3.2)
+    marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     mini_racer (0.2.0)
@@ -124,6 +126,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    pg (1.2.3)
     public_suffix (3.0.2)
     puma (3.12.0)
     rack (2.0.5)
@@ -247,6 +250,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_racer
   mqtt (= 0.5.0)
+  pg
   puma (~> 3.11)
   rails (~> 5.2.1)
   rspec-rails (~> 3.8.0)
@@ -265,4 +269,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   2.0.1
+   2.1.2


### PR DESCRIPTION
0.3.2 has been yanked:

https://rubygems.org/gems/mimemagic/versions/0.3.2

A couple of versions after that have been yanked as well. Let's use the
latest 0.3.x release. It introduces more dependencies ...